### PR TITLE
Compile fix for the latest TouchEvent changes

### DIFF
--- a/flash/events/TouchEvent.hx
+++ b/flash/events/TouchEvent.hx
@@ -35,9 +35,9 @@ class TouchEvent extends Event {
 	?id:Int, ?primary:Bool, ?lx:Float, ?ly:Float, ?sx:Float, ?sy:Float,
 	?ps:Float, ?obj:InteractiveObject, ?ctrl:Bool, ?alt:Bool, ?shift:Bool) {
 		super(type, bubbles, cancelable);
-		this.altKey = altKey;
-		this.shiftKey = shiftKey;
-		this.ctrlKey = ctrlKey;
+		altKey = alt;
+		shiftKey = shift;
+		ctrlKey = ctrl;
 		//
 		touchPointID = id;
 		sizeX = sx;


### PR DESCRIPTION
Would throw a compile error: `Cannot assign value to itself` previously.

You might want to set up travis tests to make sure everything compiles at least. :)
