### PR TITLE
Fix touches on old devices

### DIFF
--- a/flash/display/Stage.hx
+++ b/flash/display/Stage.hx
@@ -55,10 +55,10 @@ class Stage extends DisplayObjectContainer {
 		o.addEventListener("mousemove", onMouse);
 		o.addEventListener("mousewheel", onWheel);
 		// touch events (to prevent scrolling and to track mouse position):
-		o.addEventListener("touchmove", getOnTouch(0));
-		o.addEventListener("touchstart", getOnTouch(1));
-		o.addEventListener("touchend", getOnTouch(2));
-		o.addEventListener("touchcancel", getOnTouch(2));
+		Lib.document.addEventListener("touchmove", getOnTouch(0));
+		Lib.document.addEventListener("touchstart", getOnTouch(1));
+		Lib.document.addEventListener("touchend", getOnTouch(2));
+		Lib.document.addEventListener("touchcancel", getOnTouch(2));
 		//
 		mouseMtxDepth = [];
 		mouseMtxStack = [];


### PR DESCRIPTION
Old devices does not support touch listeners on `window`.

When you listen for touches on `document` rather than `window`, you are sure that it will work on all devices.
